### PR TITLE
rename to etf-trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "etf-trace"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bitfield",
+ "clap",
+ "env_logger",
+ "itm",
+ "log",
+ "probe-rs",
+ "thiserror",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,20 +638,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stm32h7-capture"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bitfield",
- "clap",
- "env_logger",
- "itm",
- "log",
- "probe-rs",
- "thiserror",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "stm32h7-capture"
+name = "etf-trace"
 version = "0.1.0"
 edition = "2021"
 
-description = "Capture ITM trace data using the STM32H7 embedded trace FIFO and store results to a file"
+description = "Capture DWT/ITM trace data using the embedded trace FIFO"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# ETF-Trace
+
+`etf-trace` uses the integrated debugging components (especially the ITM, DWT,
+CSTF, ETF) in common Cortex-M7 CPUs to capture a high rate burst of debugging
+trace data into a RAM buffer. It then reads out the buffer and parses the trace
+stream.
+
+While this is likely applicable to all CPUs that share these components, it has
+only been tested on STM32H7 processors so far.

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,10 +70,8 @@ where
 }
 
 fn main() -> anyhow::Result<()> {
-    env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("etf_trace=info"),
-    )
-    .init();
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("etf_trace=info"))
+        .init();
 
     let cli = Args::parse();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,27 @@
-//! STM32H7 tracing with the Embedded Trace FIFO
+//! ITM/DWT tracing with the Embedded Trace FIFO
 //!
 //! # Design
-//! The STM32H7 tracing infrastructure allows trace data to be generated on the SWO output, which
-//! is a UART output to the debug probe. Because of the nature of this output, the throughput is
-//! inherently limited. Additionally, there is very little buffering between ITM packet generation
-//! and SWO output, so even a small amount of trace data generated in a short time interval can
-//! result in the trace data overflowing in the SWO data path.
+//! The tracing infrastructure allows trace data to be generated on the SWO
+//! output, which is a UART output to the debug probe. Because of the nature of
+//! this output, the throughput is inherently limited. Additionally, there is
+//! very little buffering between ITM packet generation and SWO output, so even
+//! a small amount of trace data generated in a short time interval can result
+//! in the trace data overflowing in the SWO data path.
 //!
-//! To work around issues with buffering and throughput of the SWO output, this program provides a
-//! mechanism to instead capture ITM trace data within the Embedded Trace FIFO (ETF). The ETC is a
-//! 4KB FIFO stored in SRAM that can be used to buffer data before draining the trace data to an
-//! external source. The ETF supports both draining data to the TPIU via a parallel trace hardware
-//! interface as well as through the debug registers.
+//! Alternatively there is a wide, source synchronous and fast output through
+//! the TPIU. But that requires the availability of certain pins and a logic
+//! analyzer or a capable probe to capture the data.
 //!
-//! This program uses the ETF in "software" mode with no external tracing utilities required.
-//! Instead, the ETF is used to buffer up a trace which is then read out from the device via the
-//! debug probe.
+//! To work around issues with buffering and throughput of the SWO output and to
+//! avoid the need for, special hardware, this program provides a mechanism to
+//! instead capture DWT/ITM trace data within the Embedded Trace Buffer/FIFO
+//! (ETB/ETF). The ETF is a 4 KiB (usually) FIFO in SRAM that can be used to
+//! buffer data before draining the trace data to an external source. The ETF
+//! supports draining data through the debug registers.
+//!
+//! This program uses the ETF in "software" mode with no external tracing
+//! utilities required. Instead, the ETF is used to buffer up a trace which is
+//! then read out from the device via the debug probe.
 use anyhow::Context;
 use clap::Parser;
 use log::{info, warn};
@@ -65,7 +71,7 @@ where
 
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(
-        env_logger::Env::default().default_filter_or("stm32h7_capture=info"),
+        env_logger::Env::default().default_filter_or("etf_trace=info"),
     )
     .init();
 


### PR DESCRIPTION
This is not stm32h7-specific.
But it is not entirely clear how generic it is either.
Certainly, the target needs to have the required coresight components.
The trace funnel configuration may vary as well.

* [x] depends on #1
* [ ] rename repo